### PR TITLE
Add configurable timeout and improve failure reporting

### DIFF
--- a/src/jupygrader/grader.py
+++ b/src/jupygrader/grader.py
@@ -17,6 +17,7 @@ def grade_notebooks(
     export_csv: bool = True,
     csv_output_path: Optional[FilePath] = None,
     regrade_existing: bool = False,
+    execution_timeout: Optional[int] = 600,
 ) -> List[GradedResult]:
     """Grade multiple Jupyter notebooks with test cases.
 
@@ -39,6 +40,8 @@ def grade_notebooks(
             output directories. Defaults to None.
         regrade_existing: Whether to regrade notebooks even if results already exist.
             Defaults to False.
+        execution_timeout: Maximum time (in seconds) allowed for notebook execution.
+            Set to None to disable the timeout. Defaults to 600 seconds.
 
     Returns:
         List of GradedResult objects containing detailed results for each notebook.
@@ -63,6 +66,7 @@ def grade_notebooks(
         export_csv=export_csv,
         csv_output_path=csv_output_path,
         regrade_existing=regrade_existing,
+        execution_timeout=execution_timeout,
     )
 
     manager = BatchGradingManager(
@@ -91,6 +95,8 @@ def grade_single_notebook(
             - verbose: Whether to print progress information
             - regrade_existing: Whether to regrade if results exist
             - csv_output_path: Path for CSV output (if needed)
+            - execution_timeout: Maximum time (in seconds) allowed for notebook
+              execution. Set to None to disable the timeout.
 
     Returns:
         GradedResult object containing detailed results, or None if grading failed.

--- a/src/jupygrader/models/batch_grading_manager.py
+++ b/src/jupygrader/models/batch_grading_manager.py
@@ -32,6 +32,72 @@ class BatchGradingManager:
             grading_items
         )
         self.graded_results: List[GradedResult] = []
+        self._csv_rows: List[dict] = []
+
+    @staticmethod
+    def _initialize_csv_row() -> dict:
+        return {
+            "filename": None,
+            "learner_autograded_score": None,
+            "max_autograded_score": None,
+            "max_manually_graded_score": None,
+            "max_total_score": None,
+            "num_autograded_cases": None,
+            "num_passed_cases": None,
+            "num_failed_cases": None,
+            "num_manually_graded_cases": None,
+            "num_total_test_cases": None,
+            "grading_finished_at": None,
+            "grading_duration_in_seconds": None,
+            "submission_notebook_hash": None,
+            "test_cases_hash": None,
+            "grader_python_version": None,
+            "grader_platform": None,
+            "text_summary": None,
+            "is_success": None,
+        }
+
+    def _record_success(self, result: GradedResult) -> None:
+        row = self._initialize_csv_row()
+        row.update(
+            {
+                "filename": result.filename,
+                "learner_autograded_score": result.learner_autograded_score,
+                "max_autograded_score": result.max_autograded_score,
+                "max_manually_graded_score": result.max_manually_graded_score,
+                "max_total_score": result.max_total_score,
+                "num_autograded_cases": result.num_autograded_cases,
+                "num_passed_cases": result.num_passed_cases,
+                "num_failed_cases": result.num_failed_cases,
+                "num_manually_graded_cases": result.num_manually_graded_cases,
+                "num_total_test_cases": result.num_total_test_cases,
+                "grading_finished_at": result.grading_finished_at,
+                "grading_duration_in_seconds": result.grading_duration_in_seconds,
+                "submission_notebook_hash": result.submission_notebook_hash,
+                "test_cases_hash": result.test_cases_hash,
+                "grader_python_version": result.grader_python_version,
+                "grader_platform": result.grader_platform,
+                "text_summary": result.text_summary,
+                "is_success": True,
+            }
+        )
+        self._csv_rows.append(row)
+
+    def _record_failure(self, notebook_path: FilePath, error_message: str) -> None:
+        row = self._initialize_csv_row()
+        try:
+            filename = Path(notebook_path).name
+        except Exception:
+            filename = str(notebook_path)
+
+        row.update(
+            {
+                "filename": filename,
+                "text_summary": error_message,
+                "is_success": False,
+            }
+        )
+        self._csv_rows.append(row)
 
     @staticmethod
     def normalize_grading_items(
@@ -83,7 +149,7 @@ class BatchGradingManager:
         self,
     ) -> None:
         """Exports the list of GradedResult objects to a CSV file."""
-        if not self.graded_results:
+        if not self._csv_rows:
             if self.verbose:
                 print("No results to export to CSV.")
             return
@@ -107,32 +173,8 @@ class BatchGradingManager:
 
         # Extract main attributes from GradedResult objects
         data = []
-        for result in self.graded_results:
-            # Skip None results (failed grading tasks)
-            if result is None:
-                continue
-
-            # Create a dictionary with selected attributes
-            result_dict = {
-                "filename": result.filename,
-                "learner_autograded_score": result.learner_autograded_score,
-                "max_autograded_score": result.max_autograded_score,
-                "max_manually_graded_score": result.max_manually_graded_score,
-                "max_total_score": result.max_total_score,
-                "num_autograded_cases": result.num_autograded_cases,
-                "num_passed_cases": result.num_passed_cases,
-                "num_failed_cases": result.num_failed_cases,
-                "num_manually_graded_cases": result.num_manually_graded_cases,
-                "num_total_test_cases": result.num_total_test_cases,
-                "grading_finished_at": result.grading_finished_at,
-                "grading_duration_in_seconds": result.grading_duration_in_seconds,
-                "submission_notebook_hash": result.submission_notebook_hash,
-                "test_cases_hash": result.test_cases_hash,
-                "grader_python_version": result.grader_python_version,
-                "grader_platform": result.grader_platform,
-                "text_summary": result.text_summary,
-            }
-            data.append(result_dict)
+        for row in self._csv_rows:
+            data.append(row)
 
         # Create DataFrame and export to CSV
         try:
@@ -201,8 +243,18 @@ class BatchGradingManager:
                     # Add to results list only if grading succeeded
                     if graded_result is not None:
                         self.graded_results.append(graded_result)
+                        self._record_success(graded_result)
                     else:
                         num_failed_items += 1
+                        error_message = (
+                            grading_task.error_message
+                            if grading_task.error_message
+                            else "Unknown grading error"
+                        )
+                        self._record_failure(
+                            item.notebook_path,
+                            error_message,
+                        )
 
                 except Exception as e:
                     num_failed_items += 1
@@ -210,6 +262,8 @@ class BatchGradingManager:
                     if self.verbose:
                         print(f"Error: {str(e)}")
                         print(f"Failed to grade notebook: {item.notebook_path}")
+
+                    self._record_failure(item.notebook_path, str(e))
 
         # The code below continues outside the context manager
         elapsed_time = time.time() - start_time

--- a/src/jupygrader/models/grading_dataclasses.py
+++ b/src/jupygrader/models/grading_dataclasses.py
@@ -21,6 +21,7 @@ class BatchGradingConfig:
     base_files: Optional[Union[FilePath, List[FilePath], FileDict]] = None
     csv_output_path: Optional[str] = None
     regrade_existing: bool = False
+    execution_timeout: Optional[int] = 600
 
 
 @dataclass

--- a/src/jupygrader/models/grading_task.py
+++ b/src/jupygrader/models/grading_task.py
@@ -67,6 +67,8 @@ class GradingTask:
         self.nb: NotebookNode = None
         self.graded_result: GradedResult = None
         self.grading_start_time = time.time()
+        self.execution_timeout = batch_config.execution_timeout
+        self.error_message: Optional[str] = None
 
     def get_existing_graded_result(self) -> Optional[GradedResult]:
         graded_result_json_filename = f"{self.filename_base}-graded-result.json"
@@ -407,9 +409,15 @@ class GradingTask:
         self.preprocess_test_case_cells()
         self.add_grader_scripts()
 
-        client = NotebookClient(
-            self.nb, timeout=600, kernel_name="python3", allow_errors=True
-        )
+        client_kwargs = {
+            "kernel_name": "python3",
+            "allow_errors": True,
+        }
+
+        if self.execution_timeout is not None:
+            client_kwargs["timeout"] = self.execution_timeout
+
+        client = NotebookClient(self.nb, **client_kwargs)
         client.execute()
 
     def process_grading_results(self) -> None:
@@ -705,6 +713,7 @@ class GradingTask:
             json.dump(self.graded_result.to_dict(), f, indent=2)
 
     def grade(self) -> Optional[GradedResult]:
+        self.error_message = None
         try:
             with self.use_temporary_grading_environment():
                 # 1. Prepare and execute the notebook (read, preprocess, inject scripts)
@@ -719,4 +728,5 @@ class GradingTask:
             return self.graded_result
         except Exception as e:
             print(f"[Error in GradingTask.grade()]: {e}")
+            self.error_message = str(e)
             return None

--- a/tests/test_basic_workflow.py
+++ b/tests/test_basic_workflow.py
@@ -19,6 +19,7 @@ def test_basic_workflow():
             "output_path": TEST_OUTPUT_DIR,
         },
         regrade_existing=True,
+        execution_timeout=120,
     )
 
     # Check the accuracy of the result object

--- a/tests/test_failure_reporting.py
+++ b/tests/test_failure_reporting.py
@@ -1,0 +1,51 @@
+import csv
+from pathlib import Path
+
+from jupygrader import grade_notebooks
+
+
+TEST_NOTEBOOKS_DIR = Path(__file__).resolve().parent / "test-files"
+
+
+def test_failed_notebook_is_recorded_in_csv(tmp_path):
+    valid_notebook = TEST_NOTEBOOKS_DIR / "basic-workflow" / "minimal.ipynb"
+    invalid_notebook = tmp_path / "invalid.ipynb"
+    invalid_notebook.write_text("{ not valid json", encoding="utf-8")
+
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir()
+
+    csv_dir = tmp_path / "csv"
+    csv_dir.mkdir()
+
+    grading_items = [
+        {"notebook_path": valid_notebook, "output_path": output_dir},
+        {"notebook_path": invalid_notebook, "output_path": output_dir},
+    ]
+
+    results = grade_notebooks(
+        grading_items=grading_items,
+        csv_output_path=csv_dir,
+        regrade_existing=True,
+        verbose=False,
+    )
+
+    assert len(results) == 1
+
+    csv_files = list(csv_dir.glob("graded_results_*.csv"))
+    assert len(csv_files) == 1
+
+    with csv_files[0].open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert len(rows) == 2
+
+    success_rows = [row for row in rows if row.get("is_success") == "True"]
+    failure_rows = [row for row in rows if row.get("is_success") == "False"]
+
+    assert len(success_rows) == 1
+    assert len(failure_rows) == 1
+
+    assert success_rows[0]["filename"] == "minimal.ipynb"
+    assert failure_rows[0]["filename"] == "invalid.ipynb"
+    assert "Notebook does not appear to be JSON" in failure_rows[0]["text_summary"]


### PR DESCRIPTION
## Summary
- allow callers to configure notebook execution timeouts via `grade_notebooks` and `grade_single_notebook`
- propagate timeout settings to grading tasks while recording both successful and failed results in CSV exports with an `is_success` flag and error messages
- keep batch grading running when notebooks fail and cover failure reporting with new tests

## Testing
- `PYTHONPATH=$(pwd)/src pytest` *(fails: tests/test_common_workflow.py::test_mixed_workflow, tests/test_file_copy_network.py::test_file_copy_https due to required external datasets and network downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68eca3328eac8326b00163f278685ecd