### PR TITLE
Comment out notebook magic lines before execution

### DIFF
--- a/src/jupygrader/models/grading_task.py
+++ b/src/jupygrader/models/grading_task.py
@@ -29,6 +29,7 @@ from nbformat.v4 import new_code_cell, new_markdown_cell
 from ..__about__ import __version__ as jupygrader_version
 from ..constants import GRADED_RESULT_JSON_FILENAME, GRADED_RESULT_ELEMENT_ID
 from ..notebook_operations import (
+    comment_out_magic_commands,
     does_cell_contain_test_case,
     extract_user_code_from_notebook,
     extract_test_case_metadata_from_code,
@@ -406,6 +407,7 @@ class GradingTask:
 
     def prepare_and_execute_notebook(self) -> None:
         self.nb = nbformat.read(self.temp_notebook_path, as_version=4)
+        comment_out_magic_commands(self.nb)
         self.preprocess_test_case_cells()
         self.add_grader_scripts()
 

--- a/src/jupygrader/notebook_operations.py
+++ b/src/jupygrader/notebook_operations.py
@@ -144,6 +144,28 @@ def extract_user_code_from_notebook(nb: NotebookNode) -> str:
     return full_code
 
 
+def comment_out_magic_commands(nb: NotebookNode) -> NotebookNode:
+    """Comment out IPython magic/shell command lines in code cells.
+
+    Converts code lines that start with ``!`` or ``%`` (after optional leading
+    whitespace) into Python comments so notebook execution and downstream Python
+    processing can continue without syntax errors.
+
+    Args:
+        nb: Notebook to process
+
+    Returns:
+        The same notebook object with transformed code cell sources
+    """
+    pattern = re.compile(r"^(\s*)([!%].*)$", re.MULTILINE)
+
+    for cell in nb.cells:
+        if cell.cell_type == "code" and cell.source:
+            cell.source = pattern.sub(r"\1# \2", cell.source)
+
+    return nb
+
+
 def remove_code_cells_that_contain(
     nb: NotebookNode, search_str: Union[str, List[str]]
 ) -> NotebookNode:

--- a/tests/test_magic_preprocessing.py
+++ b/tests/test_magic_preprocessing.py
@@ -1,0 +1,19 @@
+import nbformat
+
+from jupygrader.notebook_operations import comment_out_magic_commands
+
+
+def test_comment_out_magic_commands_in_code_cells():
+    nb = nbformat.v4.new_notebook(
+        cells=[
+            nbformat.v4.new_code_cell("!pip install statsmodels\n%rm -rf some_dir\nx = 1"),
+            nbformat.v4.new_markdown_cell("%not-in-markdown"),
+            nbformat.v4.new_code_cell("print('ok')\n  !echo hello"),
+        ]
+    )
+
+    comment_out_magic_commands(nb)
+
+    assert nb.cells[0].source == "# !pip install statsmodels\n# %rm -rf some_dir\nx = 1"
+    assert nb.cells[1].source == "%not-in-markdown"
+    assert nb.cells[2].source == "print('ok')\n  # !echo hello"


### PR DESCRIPTION
### Motivation
- Shell/IPython magic lines in code cells (lines beginning with `!` or `%`) can cause syntax errors or unexpected behavior when the grader wraps and executes notebooks, so these lines should be neutralized before execution.

### Description
- Added `comment_out_magic_commands(nb: NotebookNode)` in `src/jupygrader/notebook_operations.py` that uses a multiline regex to rewrite leading `!`/`%` lines (including indented ones) into Python comments.
- Integrated this preprocessing into the grading flow by calling `comment_out_magic_commands(self.nb)` in `prepare_and_execute_notebook` in `src/jupygrader/models/grading_task.py` immediately after reading the temporary notebook and before `preprocess_test_case_cells()` and `add_grader_scripts()`.
- Added a unit test `tests/test_magic_preprocessing.py` that verifies code-cell magic lines are commented, markdown cells remain unchanged, and indented magic lines are handled correctly.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_magic_preprocessing.py` and it passed successfully.
- Ran `PYTHONPATH=src pytest -q tests/test_magic_preprocessing.py tests/test_basic_workflow.py`; the new unit test passed, while the end-to-end `test_basic_workflow` failed in this environment because the executed notebook kernel could not `import jupygrader`, so the grader did not produce the `_jupygrader-result.json` file (environment limitation, not the new preprocessing logic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6993cef323f883259e328043e81f9c89)