### PR TITLE
Update README and docs for AI grading modes and new API parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@
 - [📒 Create an autogradable notebook](#-create-an-autogradable-notebook)
   - [Code cell for learners](#code-cell-for-learners)
   - [Graded test cases](#graded-test-cases)
+  - [Manually graded items](#manually-graded-items)
   - [Obfuscate test cases](#obfuscate-test-cases)
   - [Add hidden test cases](#add-hidden-test-cases)
+- [🤖 AI-Assisted Grading](#-ai-assisted-grading)
+  - [Full AI grading](#full-ai-grading)
+  - [Review failed test cases](#review-failed-test-cases)
+  - [Grade manual items](#grade-manual-items)
+  - [Grade both manual and failed items](#grade-both-manual-and-failed-items)
+  - [Custom grading prompt](#custom-grading-prompt)
 - [🔧 Utility functions](#-utility-functions)
   - [Replace test cases](#replace-test-cases)
 - [📄 License](#-license)
@@ -36,12 +43,18 @@ Jupygrader is a Python package for automated grading of Jupyter notebooks. It pr
 2. **Generate comprehensive reports** in multiple formats (JSON, HTML, TXT)
 3. **Extract student code** from notebooks into separate Python files
 4. **Verify notebook integrity** by computing hashes of test cases and submissions
+5. **Grade with AI assistance** — use an LLM to grade manual items, review failures, or evaluate notebooks entirely without execution
 
 ## ✨ Key Features
 
 - Executes notebooks in a controlled, temporary environment
 - Preserves the original notebook while creating graded versions
 - Adds grader scripts to notebooks to evaluate test cases
+- Supports multiple grading modes:
+  - Automatic grading via assertions and tests
+  - Manual grading
+  - Hybrid (automatic + manual)
+  - AI-assisted grading (full or partial)
 - Generates detailed grading results including:
   - Individual test case scores
   - Overall scores and summaries
@@ -53,8 +66,6 @@ Jupygrader is a Python package for automated grading of Jupyter notebooks. It pr
   - Plaintext summary
   - Extracted Python code
 - Includes metadata like Python version, platform, and file hashes for verification
-
-Jupygrader is designed for educational settings where instructors need to grade student work in Jupyter notebooks, providing automated feedback while maintaining records of submissions and grading results.
 
 ## 📦 Installation
 
@@ -73,32 +84,32 @@ pip install --upgrade jupygrader
 ### Basic usage
 
 ```python
-import jupygrader
+from jupygrader import grade_notebooks
 
 notebook_file_path = 'path/to/notebook.ipynb'
-jupygrader.grade_notebooks(notebook_file_path)
+grade_notebooks([notebook_file_path])
 ```
 
 Supplying a `pathlib.Path()` object is supported.
 
 ```python
-import jupygrader
+from jupygrader import grade_notebooks
 from pathlib import Path
 
 notebook_path = Path('path/to/notebook.ipynb')
-jupygrader.grade_notebooks(notebook_path)
+grade_notebooks([notebook_path])
 ```
 
-If the `output_dir_path` is not specified, the output files will be stored to the same directory as the notebook file.
+If the `output_path` is not specified, the output files will be stored to the same directory as the notebook file.
 
 During grading, Jupygrader preprocesses code cells and comments out lines that start with IPython shell/magic prefixes (`!` and `%`). This prevents notebook-only commands from causing syntax errors in the Python-based grading pipeline.
 
 ### Specify the output directory
 
 ```python
-import jupygrader
+from jupygrader import grade_notebooks
 
-jupygrader.grade_notebooks([{
+grade_notebooks([{
     "notebook_path": 'path/to/notebook.ipynb',
     "output_path": 'path/to/output'
 }])
@@ -171,9 +182,21 @@ _points = 2
 pd.testing.assert_series_equal(sample_series, pd.Series([-20, -10, 10, 20]))
 ```
 
+### Manually graded items
+
+Mark a test case with `_grade_manually = True` to flag it for human (or AI) review instead of assertion-based grading.
+
+```python
+_test_case = 'explain-your-approach'
+_points = 5
+_grade_manually = True
+
+# Students write a free-response answer here
+```
+
 ### Obfuscate test cases
 
-If you want to prevent learners from seeing the test case code, you can optionally set \_obfuscate = True to base64-encode the test cases.
+If you want to prevent learners from seeing the test case code, you can optionally set `_obfuscate = True` to base64-encode the test cases.
 
 Note that this provides only basic obfuscation, and students can easily decode the string to reveal the original code.
 
@@ -226,6 +249,117 @@ _points = 2
 
 if 'is_jupygrader_env' in globals():
     pd.testing.assert_series_equal(sample_series, pd.Series([-20, -10, 10, 20]))
+```
+
+## 🤖 AI-Assisted Grading
+
+Jupygrader can use an OpenAI-compatible model to assist with grading. Set the `ai_mode` parameter to one of the following string values:
+
+| `ai_mode` | Description |
+|---|---|
+| `"off"` | No AI grading (default) |
+| `"full"` | AI grades all test cases based on notebook content — no execution required |
+| `"manual_only"` | AI grades test cases marked `_grade_manually = True` |
+| `"review_failed"` | AI reviews auto-graded test cases that failed |
+| `"manual_and_failed"` | AI grades both manual items and failed test cases |
+
+> **Note:** `openai_model` is required whenever `ai_mode` is not `"off"`. Omitting it raises a `ValueError`.
+
+### Full AI grading
+
+Use `ai_mode="full"` to have the AI evaluate every test case based solely on the notebook's content, without executing it. This is ideal for open-ended assignments, essay-style responses, or notebooks that include general instructions rather than assertion-based tests.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="full",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+In `"full"` mode, test cases are parsed directly from the notebook's source cells (no execution). Notebooks without any test case cells are still processed and output artifacts are generated.
+
+### Review failed test cases
+
+Use `ai_mode="review_failed"` to have the AI explain why auto-graded test cases failed and optionally award partial credit.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="review_failed",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+### Grade manual items
+
+Use `ai_mode="manual_only"` to have the AI grade items marked `_grade_manually = True` in the notebook.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="manual_only",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+### Grade both manual and failed items
+
+Use `ai_mode="manual_and_failed"` to combine both workflows in a single pass.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="manual_and_failed",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+### Custom grading prompt
+
+Pass `custom_prompt` to give the AI model additional context or grading criteria. This works with all AI grading modes.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb"],
+    ai_mode="full",
+    openai_client=client,
+    openai_model="gpt-4o",
+    custom_prompt=(
+        "This is a data analysis assignment. "
+        "Award full points if the student produces a correct result, even if the approach differs. "
+        "Deduct points for hard-coded values."
+    ),
+)
 ```
 
 ## 🔧 Utility functions

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,19 +6,21 @@
 
 ### `jupygrader.grade_notebooks()`
 
+The primary entry point for grading. All functionality is accessible through this single function.
+
 === "Basic"
 
     ```python
     from jupygrader import grade_notebooks
 
     # Grade a list of notebooks
-    graded_results = grade_notebooks(['path/to/notebook1.ipynb', 'path/to/notebook2.ipynb'])
+    graded_results = grade_notebooks(["path/to/notebook1.ipynb", "path/to/notebook2.ipynb"])
     ```
 
 === "With Configuration"
 
     ```python
-    from jupygrader import grade_notebooks, GradingItem
+    from jupygrader import grade_notebooks
 
     item1 = {
         "notebook_path": "path/to/notebook1.ipynb",
@@ -39,6 +41,67 @@
         execution_timeout=300  # Set execution timeout to 300 seconds (5 minutes)
     )
     ```
+
+=== "Full AI Grading"
+
+    ```python
+    import openai
+    from jupygrader import grade_notebooks
+
+    client = openai.OpenAI(api_key="your-api-key")
+
+    # Grade based on notebook content — no execution
+    results = grade_notebooks(
+        ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+        ai_mode="full",
+        openai_client=client,
+        openai_model="gpt-4o",
+    )
+    ```
+
+=== "Partial AI Grading"
+
+    ```python
+    import openai
+    from jupygrader import grade_notebooks
+
+    client = openai.OpenAI(api_key="your-api-key")
+
+    # Execute notebooks, then send manual and failed cases to AI
+    results = grade_notebooks(
+        ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+        ai_mode="manual_and_failed",
+        openai_client=client,
+        openai_model="gpt-4o",
+        custom_prompt="Award partial credit for correct reasoning even if the final answer is wrong.",
+    )
+    ```
+
+#### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `grading_items` | `list` | — | Notebook paths (strings/Paths), dicts, or `GradingItem` objects |
+| `base_files` | `str`, `Path`, `list`, or `dict` | `None` | Files copied to every notebook's working directory |
+| `verbose` | `bool` | `True` | Print progress and diagnostic information |
+| `export_csv` | `bool` | `True` | Export results to a timestamped CSV file |
+| `csv_output_path` | `str` or `Path` | `None` | Custom path for the CSV export |
+| `regrade_existing` | `bool` | `False` | Re-grade notebooks even if cached results exist |
+| `execution_timeout` | `int` or `None` | `600` | Max seconds for notebook execution; `None` disables timeout |
+| `ai_mode` | `str` | `"off"` | AI grading mode — see table below |
+| `openai_client` | `openai.OpenAI` | `None` | OpenAI client instance; required when `ai_mode` is not `"off"` |
+| `openai_model` | `str` | `None` | Model name (e.g. `"gpt-4o"`); **required** when `ai_mode` is not `"off"` |
+| `custom_prompt` | `str` | `None` | Additional grading instructions appended to the AI system prompt |
+
+#### AI grading modes
+
+| `ai_mode` | Description |
+|---|---|
+| `"off"` | No AI grading (default) |
+| `"full"` | AI grades all test cases based on notebook content — notebook is **not** executed |
+| `"manual_only"` | AI grades test cases marked `_grade_manually = True` |
+| `"review_failed"` | AI reviews failed auto-graded test cases |
+| `"manual_and_failed"` | AI grades both manual items and failed test cases |
 
 ::: jupygrader.grade_notebooks
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Easily grade Jupyter notebooks using test cases and generate detailed reports.
 
 ## Creating an autogradable notebook
 
-Creating an autogradable item is as simple as adding a cell with a test case name (`_test_case`) and points ( `_points` ) to the notebook.
+Creating an autogradable item is as simple as adding a cell with a test case name (`_test_case`) and points (`_points`) to the notebook.
 
 Assume your student is tasked to add `x` and `y`, and store the result to a new variable named `sum_xy`.
 
@@ -66,12 +66,14 @@ This will return a `GradedResult` object. Below is a sample output of the `Grade
   "grading_duration_in_seconds": 0.02,
   "test_case_results": [
     {
-      "test_case_name": "sum_xy",
+      "test_case_name": "calculate-sum",
       "points": 2,
       "available_points": 2,
       "did_pass": true,
       "grade_manually": false,
-      "message": ""
+      "error_message": null,
+      "is_graded": true,
+      "ai_feedback": null
     }
   ],
   "submission_notebook_hash": "c98c747e12a0456033956759c9daf7a0",
@@ -79,7 +81,6 @@ This will return a `GradedResult` object. Below is a sample output of the `Grade
   "grader_python_version": "3.12.5",
   "grader_platform": "Linux...",
   "jupygrader_version": "..."
-  // ... more fields here
 }
 ```
 
@@ -96,6 +97,55 @@ notebooks = glob.glob('submissions/*.ipynb')
 graded_results = grade_notebooks(notebooks)
 ```
 
+## AI-Assisted Grading
+
+Jupygrader supports AI-assisted grading via any OpenAI-compatible model. Set `ai_mode` to a string value to activate:
+
+| `ai_mode` | Description |
+|---|---|
+| `"off"` | No AI grading (default) |
+| `"full"` | AI grades all test cases based on notebook content — no execution required |
+| `"manual_only"` | AI grades test cases marked `_grade_manually = True` |
+| `"review_failed"` | AI reviews auto-graded test cases that failed |
+| `"manual_and_failed"` | AI grades both manual items and failed test cases |
+
+### Full AI grading
+
+Use `ai_mode="full"` to have the AI evaluate every test case from the notebook's source — no execution needed. Perfect for open-ended assignments and rubric-based grading.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="full",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+### Partial AI grading
+
+Run the notebook normally, then send specific cases to the AI. Use a `custom_prompt` for assignment-specific criteria.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="manual_and_failed",
+    openai_client=client,
+    openai_model="gpt-4o",
+    custom_prompt="Award partial credit for correct reasoning even if the final answer is wrong.",
+)
+```
+
 ## 📝 Summary
 
 Jupygrader is a Python package for automated grading of Jupyter notebooks. It provides a framework to:
@@ -104,6 +154,7 @@ Jupygrader is a Python package for automated grading of Jupyter notebooks. It pr
 2. **Generate comprehensive reports** in multiple formats (JSON, HTML, TXT)
 3. **Extract student code** from notebooks into separate Python files
 4. **Verify notebook integrity** by computing hashes of test cases and submissions
+5. **Grade with AI assistance** — use an LLM to grade manual items, review failures, or evaluate notebooks entirely without execution
 
 ## ✨ Key Features
 
@@ -113,12 +164,14 @@ Jupygrader is a Python package for automated grading of Jupyter notebooks. It pr
 - Supports multiple grading modes:
   - Automatic grading via assertions and tests
   - Manual grading
-  - Hybrid
+  - Hybrid (automatic + manual)
+  - AI-assisted grading (full or partial)
 - Generates detailed grading results including:
   - Individual test case scores
   - Overall scores and summaries
   - Success/failure status of each test
   - Error messages for failed test cases
+  - AI feedback when AI grading is used
 - Produces multiple output formats for instructors to review:
   - CSV export for batch grading results
   - Graded notebook (.ipynb)
@@ -159,25 +212,24 @@ Jupygrader generates multiple output formats for each graded notebook:
 Batch Processing with File Dependencies
 
 ```python
-from jupygrader import grade_notebooks, GradingItem
+from jupygrader import grade_notebooks
 
 # Configure grading with dependencies
 grading_configs = [
-    GradingItem(
-        notebook_path="assignments/hw1/student1.ipynb",
-        output_path="results/hw1",
-        copy_files=["data/dataset.csv", "utility_functions.py"]
-    ),
-    GradingItem(
-        notebook_path="assignments/hw1/student2.ipynb",
-        output_path="results/hw1",
-        copy_files=["data/dataset.csv", "utility_functions.py"]
-    )
+    {
+        "notebook_path": "assignments/hw1/student1.ipynb",
+        "output_path": "results/hw1",
+        "copy_files": ["data/dataset.csv", "utility_functions.py"],
+    },
+    {
+        "notebook_path": "assignments/hw1/student2.ipynb",
+        "output_path": "results/hw1",
+        "copy_files": ["data/dataset.csv", "utility_functions.py"],
+    },
 ]
 
 # Grade all notebooks with their dependencies
 results = grade_notebooks(grading_configs)
-
 ```
 
 Jupygrader is designed for educational settings where instructors need to grade student work in Jupyter notebooks, providing automated feedback while maintaining records of submissions and grading results.

--- a/docs/usage-library.md
+++ b/docs/usage-library.md
@@ -130,6 +130,186 @@ graded_results = grade_notebooks(
 )
 ```
 
+---
+
+## 🤖 AI-Assisted Grading
+
+Jupygrader can use an OpenAI-compatible model to assist with grading. Pass an `openai_client`, an `openai_model`, and set `ai_mode` to activate AI grading.
+
+### AI grading modes
+
+| `ai_mode` | Description |
+|---|---|
+| `"off"` | No AI grading (default) |
+| `"full"` | AI grades all test cases based on notebook content — no execution required |
+| `"manual_only"` | AI grades test cases marked `_grade_manually = True` |
+| `"review_failed"` | AI reviews auto-graded test cases that failed |
+| `"manual_and_failed"` | AI grades both manual items and failed test cases |
+
+!!! warning "openai_model is required"
+
+    You must always specify `openai_model` when using any AI grading mode. Omitting it raises a `ValueError` before any grading begins.
+
+---
+
+### Full AI grading (`"full"`)
+
+Use `ai_mode="full"` to have the AI evaluate every test case based solely on the notebook's content, **without executing the notebook**. This is ideal for:
+
+- Open-ended or essay-style assignments
+- Rubric-based grading with general instructions
+- Notebooks that don't rely on assertion-based tests
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="full",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+In `"full"` mode, test cases are parsed directly from the notebook's source cells. The notebook is never executed — the AI grades each test case by reading the notebook content. Notebooks without any test case cells are still processed and all output artifacts are generated.
+
+**Notebook structure for full AI grading**
+
+Test cases in your notebook don't need assertion code — they just need a name and point value. The AI uses the surrounding notebook context to decide whether the student's work meets the criteria.
+
+```python
+# Cell 1: student work area
+_test_case = "question-1"
+_points = 5
+_grade_manually = True
+
+# Students write their free-response answer above this cell
+```
+
+You can also have a notebook with general instructions (no test cases). In that case, grading completes and artifacts are generated, but no AI call is made since there are no cases to evaluate.
+
+---
+
+### Grade manual items only (`"manual_only"`)
+
+Use `ai_mode="manual_only"` to have the AI grade test cases marked with `_grade_manually = True`. The notebook is still executed first; only manual items are sent to the AI.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="manual_only",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+**Notebook test case example**
+
+```python
+_test_case = "explain-your-approach"
+_points = 5
+_grade_manually = True
+
+# Students write a free-response answer in the cell above
+```
+
+---
+
+### Review failed test cases (`"review_failed"`)
+
+Use `ai_mode="review_failed"` to have the AI explain why auto-graded test cases failed and optionally award partial credit. The notebook is still executed; the AI receives the error messages for failed cases.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="review_failed",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+The AI can award partial points for failed test cases but keeps `did_pass` as `False`.
+
+---
+
+### Grade both manual and failed items (`"manual_and_failed"`)
+
+Use `ai_mode="manual_and_failed"` to combine both workflows in a single pass — the AI grades manual items and reviews failed test cases.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb", "submissions/student2.ipynb"],
+    ai_mode="manual_and_failed",
+    openai_client=client,
+    openai_model="gpt-4o",
+)
+```
+
+---
+
+### Custom grading prompt
+
+Pass `custom_prompt` to give the AI additional context, assignment-specific criteria, or grading rubric details. This works with all AI grading modes.
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb"],
+    ai_mode="full",
+    openai_client=client,
+    openai_model="gpt-4o",
+    custom_prompt=(
+        "This is a data analysis assignment using pandas. "
+        "Award full points if the student arrives at the correct result, "
+        "even if the approach differs from the expected solution. "
+        "Deduct 50% of points if the student hard-codes values instead of computing them."
+    ),
+)
+```
+
+```python
+import openai
+from jupygrader import grade_notebooks
+
+client = openai.OpenAI(api_key="your-api-key")
+
+results = grade_notebooks(
+    ["submissions/student1.ipynb"],
+    ai_mode="manual_only",
+    openai_client=client,
+    openai_model="gpt-4o",
+    custom_prompt=(
+        "Grade the free-response questions based on clarity of explanation, "
+        "correct use of terminology, and depth of reasoning. "
+        "Award partial credit for partially correct answers."
+    ),
+)
+```
+
+---
+
 ## 📒 Create an autogradable notebook
 
 The instructor authors only one "solution" notebook, which contains both the solution code and test cases for all graded parts.
@@ -193,6 +373,18 @@ _test_case = 'create-a-pandas-series'
 _points = 2
 
 pd.testing.assert_series_equal(sample_series, pd.Series([-20, -10, 10, 20]))
+```
+
+### Manually graded items
+
+Mark a test case with `_grade_manually = True` to flag it for human or AI review instead of assertion-based grading.
+
+```python
+_test_case = 'explain-your-approach'
+_points = 5
+_grade_manually = True
+
+# Students write a free-response answer in the cell above
 ```
 
 ### Obfuscate test cases (Work-in-progress)


### PR DESCRIPTION
- Document all five ai_mode values ("off", "full", "manual_only", "review_failed", "manual_and_failed") with examples in README, docs/index.md, docs/usage-library.md, and docs/api.md
- Use plain strings for ai_mode throughout (no enum imports needed)
- Show only grade_notebooks() as the user-facing import in all examples
- Replace GradingItem imports with dict syntax in docs examples
- Add custom_prompt examples for both full and partial AI grading modes
- Add openai_model required-field note and ai_mode parameter table to API reference
- Add manually graded items section to README and usage-library docs
- Update GradedResult JSON example in index.md to reflect current fields

https://claude.ai/code/session_019c6N81WiZAQMwZPmmAgNLy